### PR TITLE
fix: openai env instantiation

### DIFF
--- a/websocket-server/src/server.ts
+++ b/websocket-server/src/server.ts
@@ -16,6 +16,12 @@ dotenv.config();
 
 const PORT = parseInt(process.env.PORT || "8081", 10);
 const PUBLIC_URL = process.env.PUBLIC_URL || "";
+const OPENAI_API_KEY = process.env.OPENAI_API_KEY || "";
+
+if (!OPENAI_API_KEY) {
+  console.error("OPENAI_API_KEY environment variable is required");
+  process.exit(1);
+}
 
 const app = express();
 app.use(cors());
@@ -62,7 +68,7 @@ wss.on("connection", (ws: WebSocket, req: IncomingMessage) => {
   if (type === "call") {
     if (currentCall) currentCall.close();
     currentCall = ws;
-    handleCallConnection(currentCall);
+    handleCallConnection(currentCall, OPENAI_API_KEY);
   } else if (type === "logs") {
     if (currentLogs) currentLogs.close();
     currentLogs = ws;


### PR DESCRIPTION
In `sessionManager.ts` the code loads the openAI api key from `process.env.OPENAI_API_KEY`, but does not itself load variables from a `.env` file (by running something like `dotenv.config()`), so if the key is not in the current environment a user will experience a silent failure. 

This PR now passes the api key to `sessionManager.ts` from `server.ts`, and adds an assertion that the key should be non-null. 