### PR TITLE
Update sessionManager.ts - update deprecated model

### DIFF
--- a/websocket-server/src/sessionManager.ts
+++ b/websocket-server/src/sessionManager.ts
@@ -121,7 +121,7 @@ function tryConnectModel() {
   if (isOpen(session.modelConn)) return;
 
   session.modelConn = new WebSocket(
-    "wss://api.openai.com/v1/realtime?model=gpt-4o-realtime-preview-2024-12-17",
+    "wss://api.openai.com/v1/realtime?model=gpt-4o-realtime-preview-2025-06-03",
     {
       headers: {
         Authorization: `Bearer ${session.openAIApiKey}`,


### PR DESCRIPTION
Update deprecated  realtime model as per official notice:

> As part of our continuous upgrade process, we are deprecating [gpt-4o-realtime-preview-2024-10-01](http://url3243.email.openai.com/ls/click?upn=u001.IQLfsj4kk-2BK7JhymNusRMkuuWNTB2xtKMTOzsaHXXCy-2Fd9-2FSW-2F4zB6W76e4MzLX023N2Zexb9hUYUc6574ViiPu-2FCpN-2BwPp-2FKNGuZ8eLFis-3Dzx-b_EusFqD1e20tS5AehrlRQE-2BSbW8m2I68ZlIUHurjMMLt1rJbAX1c7aJAU7ZBMaHJw6SG9pW-2BfNinIUwKX1j0ZqiSStn8XnFc7YwY2gFBK23W2Pg5G4nj7oMbRJD2fSCpdU9Dxy9B-2Bx54LYhMCXMM8tPmVlxm8SxzzAHhpYui2frYsL5eaNpypdrFwob8JyYDnGarkY8gtyQspRjQ8tKjj-2F74WLFEuvjaBkEnQhgTYKrFwz5lXv1jGeeKjFeEf1CqP2uDtbDpOWys0fjrWZjbYjedUwI2AHtJUAyT8AAqHH4RJ9A3pumOl8GI7UVhZJaRBndCSYpUpq9DO0ji-2FpPOwSh2Wz4LwAz1gAzEBT5NRUzTgKimWnRipeQQ0n4uzrZAnCRioruDaY7LHDz0luUtWzJC-2BiOu5Gdi-2BeWwkqTeAJPaOU9GFBTIw0KRyTTgOEHd2ufJdfsbph0op8B7t-2FJtslZgHJEO9HUlReNwRO0-2BYGFteYp-2BRCm9KxzsWN4tBpFsG-2FDJ9Gf6Ts2Al9Xr-2BRSh7TBWy4lHcEiAmmn8jTsZ5If4PFl4sHIAW2we-2B54dtsdOysKPjm8iApzIx-2FRVfU7piAFnnEtjw9nsWCEwBTwjhDGO8IfyT3yqmBY25BrhHxrqvb1pZkRlnDj-2BPU14xp-2BUKEk5pPGmyRrAxV5j8It0q8kjs8VaOra3v07iqydaC7wDsKvJzKEXSrK-2BElwWaKBWFl88qKmnD-2FqI-2BaSOvHB0Vn1mXi83QTxsyRvxszM4Z-2Bb60ln13bie1-2F-2FTU8voYwWJyW01DCc573B7fyDrmrVTNvvsXQwWzviVfUF3lPyQVvOdTpU1Uq9Ksfm2hYkckg-2BsWHE6ifQwRCXz4w74lJ5uI2B7s2VTlEqodlWLAqF8nkWIhN-2FVfJCccQaryjYgMYhb64Vut-2FLhgzLkZs3UslmWv7s-2BaeyxYN3nVV1QMXHHPFxUZNO11zaCTK00GwcIiiPnrJjbGu4v3hFPvXPJKAoAF1hxozQpIWpFLSuxaeitod-2Fbx3NjVlXBt0AQadoQ09qCLwZKskVyQ2L-2FhS8kmpgZhsBAqTcvu7ZWHOfRfd2j4WVL6VbQyP6eocEYmwfEjtGR61Q-3D-3D). Access to this model will be shut off on September 10, 2025.
> 
> 
> Ahead of the shutdown timeline September 10, we encourage you to switch your model parameter to gpt-4o-realtime-preview-2025-06-03 or gpt-4o-realtime-preview.
> 
> 
> The latest model has improved instruction following reliability, tool calling consistency, and interruption behavior of our speech-to-speech model, and introduces a new speed parameter in the API that lets you control how fast the voice speaks during each session. To explore the new version now, specify gpt-4o-realtime-preview-2025-06-03 as the model parameter in the API.